### PR TITLE
Added white space collapse functionality

### DIFF
--- a/pkg/sigma/v2/ident_test.go
+++ b/pkg/sigma/v2/ident_test.go
@@ -358,14 +358,14 @@ func TestParseIdent(t *testing.T) {
 				}
 				switch c.IdentTypes[j] {
 				case identKeyword:
-					kw, err := NewKeyword(val)
+					kw, err := NewKeyword(val, false)
 					if err != nil {
 						t.Fatalf("ident case %d token %d failed to parse as keyword: %s",
 							i+1, j+1, err)
 					}
 					keywords = append(keywords, kw)
 				case identSelection:
-					sel, err := NewSelectionBranch(val)
+					sel, err := NewSelectionBranch(val, false)
 					if err != nil {
 						t.Fatalf("ident case %d token %d failed to parse as selection: %s",
 							i+1, j+1, err)

--- a/pkg/sigma/v2/parser.go
+++ b/pkg/sigma/v2/parser.go
@@ -23,6 +23,11 @@ type parser struct {
 
 	// resulting rule that can be collected later
 	result Branch
+
+	// if true, stops the parser from collapsing whitespace in non-regex rules (default is false to collapse)
+	// and the data that will be matched against them; default is to collapse whitespace to allow for better
+	// matching in the event that a bad actor attempts to pad whitespace inot a command to fool the engine
+	noCollapseWS bool
 }
 
 func (p *parser) run() error {
@@ -41,7 +46,7 @@ func (p *parser) run() error {
 }
 
 func (p *parser) parse() error {
-	res, err := newBranch(p.sigma, p.tokens, 0)
+	res, err := newBranch(p.sigma, p.tokens, 0, p.noCollapseWS)
 	if err != nil {
 		return err
 	}

--- a/pkg/sigma/v2/parser_test.go
+++ b/pkg/sigma/v2/parser_test.go
@@ -430,9 +430,26 @@ var detection13_negative = `
 }
 `
 
+//this has a hacky test; we set 'noCollapseWSNeg' in the parseTestCast struct for this case specifically
+//doing so will turn off collapsing the whitespace for the negative test and cause this to fail detection
+var detection14 = `
+detection:
+  condition: "selection"
+  selection:
+    SomeName|contains:
+      - 'whitespace   collapse	testing'
+`
+
+var detection14_case = `
+{
+	"SomeName":       "whitespace\t\tcollapse         testing"
+}
+`
+
 type parseTestCase struct {
-	Rule     string
-	Pos, Neg []string
+	Rule            string
+	Pos, Neg        []string
+	noCollapseWSNeg bool
 }
 
 var parseTestCases = []parseTestCase{
@@ -501,6 +518,16 @@ var parseTestCases = []parseTestCase{
 		Pos:  []string{detection13_positive},
 		Neg:  []string{detection13_negative},
 	},
+	{
+		Rule:            detection14,
+		Pos:             []string{detection14_case},
+		noCollapseWSNeg: false, //ensures whitespace is collapsed and everything matches
+	},
+	{
+		Rule:            detection14,
+		Neg:             []string{detection14_case},
+		noCollapseWSNeg: true, //turns off whitespace collapsing and causing a non-match
+	},
 }
 
 func TestTokenCollect(t *testing.T) {
@@ -526,8 +553,9 @@ func TestParse(t *testing.T) {
 		}
 		expr := rule.Detection["condition"].(string)
 		p := &parser{
-			lex:   lex(expr),
-			sigma: rule.Detection,
+			lex:          lex(expr),
+			sigma:        rule.Detection,
+			noCollapseWS: c.noCollapseWSNeg,
 		}
 		if err := p.collect(); err != nil {
 			t.Fatalf("rule parser case %d failed to collect lexical tokens, %s", i+1, err)

--- a/pkg/sigma/v2/rule.go
+++ b/pkg/sigma/v2/rule.go
@@ -41,7 +41,7 @@ type Rule struct {
 }
 
 // NewRuleList reads a list of sigma rule paths and parses them to rule objects
-func NewRuleList(files []string, skip bool) ([]RuleHandle, error) {
+func NewRuleList(files []string, skip, noCollapseWS bool) ([]RuleHandle, error) {
 	if len(files) == 0 {
 		return nil, fmt.Errorf("missing rule file list")
 	}
@@ -66,8 +66,9 @@ loop:
 			return nil, &ErrParseYaml{Err: err, Path: path}
 		}
 		rules = append(rules, RuleHandle{
-			Path: path,
-			Rule: r,
+			Path:         path,
+			Rule:         r,
+			NoCollapseWS: noCollapseWS,
 			Multipart: func() bool {
 				return !bytes.HasPrefix(data, []byte("---")) && bytes.Contains(data, []byte("---"))
 			}(),

--- a/pkg/sigma/v2/rule.go
+++ b/pkg/sigma/v2/rule.go
@@ -16,8 +16,9 @@ import (
 type RuleHandle struct {
 	Rule
 
-	Path      string `json:"path"`
-	Multipart bool   `json:"multipart"`
+	Path         string `json:"path"`
+	Multipart    bool   `json:"multipart"`
+	NoCollapseWS bool   `json:"noCollapseWS"`
 }
 
 // Rule defines raw rule conforming to sigma rule specification

--- a/pkg/sigma/v2/ruleset.go
+++ b/pkg/sigma/v2/ruleset.go
@@ -53,7 +53,7 @@ func NewRuleset(c Config) (*Ruleset, error) {
 		return nil, err
 	}
 	var fail, unsupp int
-	rules, err := NewRuleList(files, !c.FailOnYamlParse)
+	rules, err := NewRuleList(files, !c.FailOnYamlParse, c.NoCollapseWS)
 	if err != nil {
 		switch e := err.(type) {
 		case ErrBulkParseYaml:

--- a/pkg/sigma/v2/ruleset.go
+++ b/pkg/sigma/v2/ruleset.go
@@ -14,6 +14,9 @@ type Config struct {
 	// parse yaml or rule AST
 	// this parameter will cause an early error return instead
 	FailOnRuleParse, FailOnYamlParse bool
+	// by default, we will collapse whitespace for both rules and data of non-regex rules and non-regex compared data
+	//setthig this to true turns that behavior off
+	NoCollapseWS bool
 }
 
 func (c Config) validate() error {

--- a/pkg/sigma/v2/tree_test.go
+++ b/pkg/sigma/v2/tree_test.go
@@ -42,6 +42,7 @@ func TestTreeParse(t *testing.T) {
 	}
 }
 
+//we should probably add an alternative to this benchmark to include noCollapseWS on or off (we collapse by default now)
 func benchmarkCase(b *testing.B, rawRule, rawEvent string) {
 	var rule Rule
 	if err := yaml.Unmarshal([]byte(parseTestCases[0].Rule), &rule); err != nil {

--- a/pkg/sigma/v2/tree_test.go
+++ b/pkg/sigma/v2/tree_test.go
@@ -13,7 +13,7 @@ func TestTreeParse(t *testing.T) {
 		if err := yaml.Unmarshal([]byte(c.Rule), &rule); err != nil {
 			t.Fatalf("tree parse case %d failed to unmarshal yaml, %s", i+1, err)
 		}
-		p, err := NewTree(RuleHandle{Rule: rule})
+		p, err := NewTree(RuleHandle{Rule: rule, NoCollapseWS: c.noCollapseWSNeg})
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Per commit notes: Added collapse white space functionality and made it the default behavior.  This functionality will collapse white space in non-regex rules and data for non-regex matching.  This should allow us to avoid potential poisoning from someone padding white space into certain commands to avoid rule detection.

Regex (and data matching against it) is exempt from the above due to the complexity of regex to begin with.

Behavior may be disabled by setting NoCollapseWS on the Config struct to true.