### PR TITLE
rule: add description and json tags to result

### DIFF
--- a/rule.go
+++ b/rule.go
@@ -112,9 +112,11 @@ type Tags []string
 
 // Result is an object returned on positive sigma match
 type Result struct {
-	Tags
+	Tags `json:"tags"`
 
-	ID, Title string
+	ID          string `json:"id"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
 }
 
 // Results should be returned when single event matches multiple rules

--- a/tree.go
+++ b/tree.go
@@ -27,9 +27,10 @@ func (t Tree) Eval(e Event) (*Result, bool) {
 	}
 	if match {
 		return &Result{
-			ID:    t.Rule.ID,
-			Title: t.Rule.Title,
-			Tags:  t.Rule.Tags,
+			ID:          t.Rule.ID,
+			Title:       t.Rule.Title,
+			Tags:        t.Rule.Tags,
+			Description: t.Rule.Description,
 		}, true
 	}
 	return nil, false


### PR DESCRIPTION
* Description field provides a lot more context than rule title;
* Result was missing Go JSON tags, making encoded result ugly;