### PR TITLE
Added Author field in Result struct

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/markuskont/go-sigma-rule-engine
+module github.com/M00NLIG7/go-sigma-rule-engine
 
 go 1.18
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/M00NLIG7/go-sigma-rule-engine
+module github.com/markuskont/go-sigma-rule-engine
 
 go 1.18
 

--- a/rule.go
+++ b/rule.go
@@ -116,6 +116,7 @@ type Result struct {
 	ID          string `json:"id"`
 	Title       string `json:"title"`
 	Description string `json:"description"`
+	Author string `json:"author"`
 }
 
 // Results should be returned when single event matches multiple rules

--- a/tree.go
+++ b/tree.go
@@ -31,6 +31,7 @@ func (t Tree) Eval(e Event) (*Result, bool) {
 			Title:       t.Rule.Title,
 			Tags:        t.Rule.Tags,
 			Description: t.Rule.Description,
+			Author: t.Rule.Author,
 		}, true
 	}
 	return nil, false


### PR DESCRIPTION
IIRC, the DRL, at least for the base Sigma repo, requests that the author's name be published for a Sigma rule match. Just a simple two line change but I am using your repo so i figured it should be compliant :+1:  .