### PR TITLE
Add support for tag-based rule selection

### DIFF
--- a/examples/parse-rules/main.go
+++ b/examples/parse-rules/main.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/parse-rules/main.go
+++ b/examples/parse-rules/main.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -41,7 +41,7 @@ func main() {
 		log.Println(f)
 	}
 	log.Println("Parsing rule yaml files")
-	rules, err := sigma.NewRuleList(files, true, false)
+	rules, err := sigma.NewRuleList(files, true, false, nil)
 	if err != nil {
 		switch err.(type) {
 		case sigma.ErrBulkParseYaml:

--- a/examples/simple-rule-mapping/main.go
+++ b/examples/simple-rule-mapping/main.go
@@ -42,7 +42,7 @@ func main() {
 		NoCollapseWS:    false,
 		FailOnRuleParse: false,
 		FailOnYamlParse: false,
-	})
+	}, nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/simple-streamer/main.go
+++ b/examples/simple-streamer/main.go
@@ -26,7 +26,7 @@ func main() {
 		NoCollapseWS:    false,
 		FailOnRuleParse: false,
 		FailOnYamlParse: false,
-	})
+	}, nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/threaded-streamer/main.go
+++ b/examples/threaded-streamer/main.go
@@ -33,7 +33,7 @@ func main() {
 		NoCollapseWS:    false,
 		FailOnRuleParse: false,
 		FailOnYamlParse: false,
-	})
+	}, nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/rule.go
+++ b/rule.go
@@ -41,7 +41,7 @@ type Rule struct {
 }
 
 // NewRuleList reads a list of sigma rule paths and parses them to rule objects
-func NewRuleList(files []string, skip, noCollapseWS bool) ([]RuleHandle, error) {
+func NewRuleList(files []string, skip, noCollapseWS bool, tags []string) ([]RuleHandle, error) {
 	if len(files) == 0 {
 		return nil, fmt.Errorf("missing rule file list")
 	}
@@ -65,6 +65,21 @@ loop:
 			}
 			return nil, &ErrParseYaml{Err: err, Path: path}
 		}
+	tagLoop:
+		for _, tag := range tags {
+			for _, ruleTag := range r.Tags {
+				if ruleTag == tag {
+					continue tagLoop
+				}
+			}
+			errs = append(errs, ErrParseYaml{
+				Path:  path,
+				Count: i,
+				Err:   fmt.Errorf("rule does not have required %s tag", tag),
+			})
+			continue loop
+		}
+
 		rules = append(rules, RuleHandle{
 			Path:         path,
 			Rule:         r,

--- a/ruleset.go
+++ b/ruleset.go
@@ -47,7 +47,7 @@ type Ruleset struct {
 }
 
 // NewRuleset instanciates a Ruleset object
-func NewRuleset(c Config) (*Ruleset, error) {
+func NewRuleset(c Config, tags []string) (*Ruleset, error) {
 	if err := c.validate(); err != nil {
 		return nil, err
 	}
@@ -56,7 +56,7 @@ func NewRuleset(c Config) (*Ruleset, error) {
 		return nil, err
 	}
 	var fail, unsupp int
-	rules, err := NewRuleList(files, !c.FailOnYamlParse, c.NoCollapseWS)
+	rules, err := NewRuleList(files, !c.FailOnYamlParse, c.NoCollapseWS, tags)
 	if err != nil {
 		switch e := err.(type) {
 		case ErrBulkParseYaml:


### PR DESCRIPTION
This PR adds support for a tag based rule selection. If a slice of tags is provided, all rules that do not have all requested tags will be ignored.