### PR TITLE
Made glob matching case-insensitive by default (reuse of 'lower' boolean var on creation)

### DIFF
--- a/ident.go
+++ b/ident.go
@@ -273,7 +273,11 @@ func newSelectionFromMap(expr map[string]interface{}, noCollapseWS bool) (*Selec
 		}
 		switch pat := pattern.(type) {
 		case string:
-			m, err := NewStringMatcher(mod, false, all, noCollapseWS, pat)
+			lower := true
+			if mod == TextPatternRegex {
+				lower = false
+			}
+			m, err := NewStringMatcher(mod, lower, all, noCollapseWS, pat)
 			if err != nil {
 				return nil, err
 			}
@@ -305,7 +309,11 @@ func newSelectionFromMap(expr map[string]interface{}, noCollapseWS bool) (*Selec
 			}
 			switch k {
 			case reflect.String:
-				m, err := NewStringMatcher(mod, false, all, noCollapseWS, castIfaceToString(pat)...)
+				lower := true
+				if mod == TextPatternRegex {
+					lower = false
+				}
+				m, err := NewStringMatcher(mod, lower, all, noCollapseWS, castIfaceToString(pat)...)
 				if err != nil {
 					return nil, err
 				}

--- a/ident_test.go
+++ b/ident_test.go
@@ -278,6 +278,52 @@ var identSelection2neg2 = `
 	}
 }
 `
+var identSelection4 = `
+---
+detection:
+  condition: selection
+  selection:
+   - winlog.event_data.ScriptBlockText|contains:
+      - '*wmic*shadowcopy*delete'
+`
+
+var identSelection4pos1 = `
+{
+  "event_id": 1337,
+  "channel": "Microsoft-Windows-PowerShell/Operational",
+  "task": "Execute a Remote Command",
+  "opcode": "On create calls",
+  "version": 1,
+  "record_id": 1559,
+	"winlog": {
+		"event_data": {
+			"MessageNumber": "1",
+			"MessageTotal": "1",
+			"ScriptBlockText": "someData WMic shaDOWcOpY     dEleTe",
+			"ScriptBlockId": "ecbb39e8-1896-41be-b1db-9a33ed76314b"
+		}
+	}
+}
+`
+
+var identSelection4neg1 = `
+{
+  "event_id": 1337,
+  "channel": "Microsoft-Windows-PowerShell/Operational",
+  "task": "Execute a Remote Command",
+  "opcode": "On create calls",
+  "version": 1,
+  "record_id": 1559,
+	"winlog": {
+		"event_data": {
+			"MessageNumber": "1",
+			"MessageTotal": "1",
+			"ScriptBlockText": "something normal",
+			"ScriptBlockId": "ecbb39e8-1896-41be-b1db-9a33ed76314b"
+		}
+	}
+}
+`
 
 var selectionCases = []identTestCase{
 	{
@@ -302,6 +348,14 @@ var selectionCases = []identTestCase{
 		IdentTypes: []identType{identSelection},
 		Pos:        []string{identSelection2pos1},
 		Neg:        []string{identSelection2neg1, identSelection2neg2},
+		Example:    ident2,
+	},
+	{
+		IdentCount: 1,
+		Rule:       identSelection4,
+		IdentTypes: []identType{identSelection},
+		Pos:        []string{identSelection4pos1},
+		Neg:        []string{identSelection4neg1},
 		Example:    ident2,
 	},
 }


### PR DESCRIPTION
Re: https://github.com/markuskont/go-sigma-rule-engine/issues/27

Modified gobwas/glob handler to do insensitive comparisons by default (`ToLower` everything); reusing the lower flag as we do everywhere else.

@markuskont I noted we have some calls to `newStringKeyword` that explicitly set the `lower` flag to false, which may not be desirable; I did not update those yet, but I suspect it's an issue? (see lines 96 and 109 in `ident.go`).